### PR TITLE
Add unbind and clearAllLifecycleObservers methods to View class

### DIFF
--- a/core/src/jsMain/kotlin/com/narbase/kunafa/core/components/View.kt
+++ b/core/src/jsMain/kotlin/com/narbase/kunafa/core/components/View.kt
@@ -71,6 +71,10 @@ actual open class View(
         lifecycleObserversList.add(lifecycleObserver)
     }
 
+    override fun unbind(lifecycleObserver: LifecycleObserver) {
+        lifecycleObserversList.remove(lifecycleObserver)
+    }
+
     var isVisible: Boolean = true
         set(value) {
             field = value
@@ -158,6 +162,7 @@ actual open class View(
         get() = _children
 
     private fun childrenCopy(): Set<View> = mutableSetOf<View>().apply { addAll(children) }
+    private fun lifecycleObserversCopy(): Set<LifecycleObserver> = mutableSetOf<LifecycleObserver>().apply { addAll(lifecycleObserversList) }
 
 
     internal open fun addToParent() {
@@ -214,6 +219,13 @@ actual open class View(
             child.postOnViewRemoved()
         }
         _children.clear()
+    }
+
+    open fun clearAllLifecycleObservers() {
+        val lifecycleObserversCopy = lifecycleObserversCopy()
+        lifecycleObserversCopy.forEach { lifecycleObserver ->
+            unbind(lifecycleObserver)
+        }
     }
 
 

--- a/core/src/jsMain/kotlin/com/narbase/kunafa/core/lifecycle/LifecycleOwner.kt
+++ b/core/src/jsMain/kotlin/com/narbase/kunafa/core/lifecycle/LifecycleOwner.kt
@@ -3,4 +3,5 @@ package com.narbase.kunafa.core.lifecycle
 interface LifecycleOwner {
     val isViewMounted: Boolean
     fun bind(lifecycleObserver: LifecycleObserver)
+    fun unbind(lifecycleObserver: LifecycleObserver)
 }

--- a/core/src/jsTest/kotlin/com/narbase/kunafa/core/LifecycleObserverTest.kt
+++ b/core/src/jsTest/kotlin/com/narbase/kunafa/core/LifecycleObserverTest.kt
@@ -1,0 +1,115 @@
+package com.narbase.kunafa.core
+
+import com.narbase.kunafa.core.components.View
+import com.narbase.kunafa.core.lifecycle.LifecycleObserver
+import com.narbase.kunafa.core.lifecycle.LifecycleOwner
+import kotlin.test.Test
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class LifecycleObserverTest {
+
+    class MockMountedView private constructor(parent: View? = null) : View(parent) {
+        override val isViewMounted = true
+
+        companion object {
+            operator fun invoke(): MockMountedView {
+                return MockMountedView(MockMountedView())
+            }
+        }
+    }
+
+    class MockLifecycleObserver : LifecycleObserver {
+        var onViewCreatedCalled = false
+        var viewWillMountCalled = false
+        var onViewMountedCalled = false
+        var viewWillBeRemovedCalled = false
+        var onViewRemovedCalled = false
+
+        override fun onViewCreated(lifecycleOwner: LifecycleOwner) {
+            onViewCreatedCalled = true
+        }
+
+        override fun viewWillMount(lifecycleOwner: LifecycleOwner) {
+            viewWillMountCalled = true
+        }
+
+        override fun onViewMounted(lifecycleOwner: LifecycleOwner) {
+            onViewMountedCalled = true
+        }
+
+        override fun viewWillBeRemoved(lifecycleOwner: LifecycleOwner) {
+            viewWillBeRemovedCalled = true
+        }
+
+        override fun onViewRemoved(lifecycleOwner: LifecycleOwner) {
+            onViewRemovedCalled = true
+        }
+
+        fun resetState() {
+            onViewCreatedCalled = false
+            viewWillMountCalled = false
+            onViewMountedCalled = false
+            viewWillBeRemovedCalled = false
+            onViewRemovedCalled = false
+        }
+
+        fun assertAllMethodsCalled() {
+            assertTrue(onViewCreatedCalled, "Expected 'onViewCreated' to be called, but it was not.")
+            assertTrue(viewWillMountCalled, "Expected 'viewWillMount' to be called, but it was not.")
+            assertTrue(onViewMountedCalled, "Expected 'onViewMounted' to be called, but it was not.")
+            assertTrue(viewWillBeRemovedCalled, "Expected 'viewWillBeRemoved' to be called, but it was not.")
+            assertTrue(onViewRemovedCalled, "Expected 'onViewRemoved' to be called, but it was not.")
+        }
+
+        fun assertNoMethodsCalled() {
+            assertFalse(onViewCreatedCalled, "Expected 'onViewCreated' not to be called, but it was.")
+            assertFalse(viewWillMountCalled, "Expected 'viewWillMount' not to be called, but it was.")
+            assertFalse(onViewMountedCalled, "Expected 'onViewMounted' not to be called, but it was.")
+            assertFalse(viewWillBeRemovedCalled, "Expected 'viewWillBeRemoved' not to be called, but it was.")
+            assertFalse(onViewRemovedCalled, "Expected 'onViewRemoved' not to be called, but it was.")
+        }
+    }
+
+
+    private fun triggerLifecycleChanges(view: View) {
+        view.postOnViewCreated()
+        view.postViewWillMount()
+        view.postOnViewMounted()
+        view.postViewWillBeRemoved()
+        view.postOnViewRemoved()
+    }
+
+    @Test
+    fun testUnbindLifecycleObserver() {
+        val view = MockMountedView()
+        val observer = MockLifecycleObserver()
+        view.bind(observer)
+
+        triggerLifecycleChanges(view)
+        observer.assertAllMethodsCalled()
+
+        observer.resetState()
+        view.unbind(observer)
+
+        triggerLifecycleChanges(view)
+        observer.assertNoMethodsCalled()
+    }
+
+    @Test
+    fun testClearAllLifecycleObservers() {
+        val view = MockMountedView()
+        val observers = listOf(MockLifecycleObserver(), MockLifecycleObserver())
+        observers.forEach { view.bind(it) }
+
+        triggerLifecycleChanges(view)
+        observers.forEach { it.assertAllMethodsCalled() }
+
+        observers.forEach { it.resetState() }
+        view.clearAllLifecycleObservers()
+
+        triggerLifecycleChanges(view)
+        observers.forEach { it.assertNoMethodsCalled() }
+    }
+
+}


### PR DESCRIPTION
## Summary

This pull request adds two new methods to the `View` class to improve lifecycle observer management:

1. **`unbind(lifecycleObserver: LifecycleObserver)`**
   - Allows removing a specific `LifecycleObserver` from a `View`.

2. **`clearAllLifecycleObservers()`**
   - Provides a way to remove all bound `LifecycleObservers` from a `View`.

## Changes

- **View Class Updates:**
  - Added the `unbind` method to remove a single observer.
  - Added the `clearAllLifecycleObservers` method to remove all observers at once.

- **Testing:**
  - Created tests in the `LifecycleObserverTest` class.
  - Tests cover both new methods to ensure they work as expected.

## Benefits

- **Enhanced Control:**
  - Developers can now unbind observers when they are no longer needed.
  - Simplifies the process of cleaning up observers.

- **Resource Management:**
  - Helps prevent potential memory leaks by ensuring observers do not remain bound unnecessarily.
  - Improves the efficiency of the application by managing observers effectively.

## Testing Details

- **`testUnbindLifecycleObserver`:**
  - Verifies that after unbinding, the observer no longer receives lifecycle events.

- **`testClearAllLifecycleObservers`:**
  - Ensures that all observers are removed and none receive events after clearing.

## Conclusion

These additions enhance the `View` class by providing better lifecycle observer management, making it easier to maintain and improve application performance.